### PR TITLE
added playbook steps to rectify 'openstacksdk required' in playbook

### DIFF
--- a/roles/setup-workstation/tasks/pre-tasks.yml
+++ b/roles/setup-workstation/tasks/pre-tasks.yml
@@ -4,11 +4,23 @@
   yum:
     name:
       - python-pip
+  warn: false
 - name: Install openstacksdk library
   pip:
-    name: openstacksdk
+    name: "{{ item }}"
     state: latest
     extra_args: -U
+  with_items:
+    - futures
+    - openstacksdk
+- name: fix import statements for queue library in Python2.7
+  replace:
+    path: "{{ item }}"
+    regex: 'import queue'
+    replace: 'import Queue from queue'
+  with_items:
+    - /usr/lib/python2.7/site-packages/openstack/cloud/openstackcloud.py
+    - /usr/lib/python2.7/site-packages/openstack/utils.py
 - name: Create clouds.yaml file
   blockinfile:
     create: yes

--- a/roles/setup-workstation/tasks/pre-tasks.yml
+++ b/roles/setup-workstation/tasks/pre-tasks.yml
@@ -4,7 +4,7 @@
   yum:
     name:
       - python-pip
-  warn: false
+    warn: false
 - name: Install openstacksdk library
   pip:
     name: "{{ item }}"


### PR DESCRIPTION
not sure if this was apart of the homework assignment, but my workstation had trouble with the openstacksdk python library, and I have introduced steps into **roles/setup-workstation/pre-tasks.yml** to rectify this.

hopefully it helps other students as well.

Sarabraj Singh - Senior Consultant - Redhat